### PR TITLE
runtime: use custom escape function

### DIFF
--- a/lib/handlebars.runtime.js
+++ b/lib/handlebars.runtime.js
@@ -17,7 +17,7 @@ function create() {
   hb.SafeString = SafeString;
   hb.Exception = Exception;
   hb.Utils = Utils;
-  hb.escapeExpression = Utils.escapeExpression;
+  hb.escapeExpression = env.escapeExpression;
 
   hb.VM = runtime;
   hb.template = function(spec) {


### PR DESCRIPTION
Without this change, the line

    hb.escapeExpression = Utils.escapeExpression;

in top-level `create()` is unused.

Users who use a custom escape can only do so by modifying the global Utils.escapeExpression.